### PR TITLE
Change version of moment-range due to non existing 3.1 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "peerDependencies": {
     "moment": "^2.11",
-    "moment-range": "^3.1",
+    "moment-range": "^3.0",
     "prop-types": "*",
     "react": "*",
     "react-dom": ">=0.14.0"


### PR DESCRIPTION
Hey,
Could you please consider if you didn't make a mistake while adding versions because moment-range 3.1 is released yet and if throws error in my app.