### PR TITLE
Add new props: dateFormat. Fix the formating y-label

### DIFF
--- a/src/dayz.js
+++ b/src/dayz.js
@@ -15,6 +15,7 @@ export default class Dayz extends React.Component {
         events:            PropTypes.instanceOf(EventsCollection),
         display:           PropTypes.oneOf(['month', 'week', 'day']),
         timeFormat:        PropTypes.string,
+        dateFormat:        PropTypes.string,
         displayHours:      PropTypes.array,
         onEventClick:      PropTypes.func,
         editComponent:     PropTypes.func,
@@ -87,7 +88,7 @@ export default class Dayz extends React.Component {
         const classes = ['dayz', this.props.display];
         return (
             <div className={classes.join(' ')}>
-                <XLabels date={this.props.date} display={this.props.display} />
+                <XLabels date={this.props.date} display={this.props.display} dateFormat={this.props.dateFormat} />
                 <div className="body">
                     <YLabels
                         layout={this.layout}

--- a/src/dayz.js
+++ b/src/dayz.js
@@ -88,7 +88,11 @@ export default class Dayz extends React.Component {
         const classes = ['dayz', this.props.display];
         return (
             <div className={classes.join(' ')}>
-                <XLabels date={this.props.date} display={this.props.display} dateFormat={this.props.dateFormat} />
+                <XLabels
+                    date={this.props.date}
+                    display={this.props.display}
+                    dateFormat={this.props.dateFormat}
+                />
                 <div className="body">
                     <YLabels
                         layout={this.layout}

--- a/src/x-labels.js
+++ b/src/x-labels.js
@@ -7,6 +7,7 @@ export default class XLabels extends React.Component {
     static propTypes = {
         display: PropTypes.oneOf(['month', 'week', 'day']),
         date:    PropTypes.object.isRequired,
+        dateFormat: PropTypes.string
     }
 
     get days() {
@@ -23,7 +24,9 @@ export default class XLabels extends React.Component {
     }
 
     render() {
-        const format = 'month' === this.props.display ? 'dddd' : 'ddd, MMM Do';
+        const format = 'month' === this.props.display 
+            ? 'dddd' 
+            : this.props.dateFormat ? this.props.dateFormat : 'ddd, MMM Do';
 
         return (
             <div className="x-labels">{this.days.map(day => <div key={day.format('YYYYMMDD')} className="day-label">

--- a/src/x-labels.js
+++ b/src/x-labels.js
@@ -7,7 +7,7 @@ export default class XLabels extends React.Component {
     static propTypes = {
         display: PropTypes.oneOf(['month', 'week', 'day']),
         date:    PropTypes.object.isRequired,
-        dateFormat: PropTypes.string
+        dateFormat: PropTypes.string,
     }
 
     get days() {
@@ -24,9 +24,10 @@ export default class XLabels extends React.Component {
     }
 
     render() {
-        const format = 'month' === this.props.display 
-            ? 'dddd' 
-            : this.props.dateFormat ? this.props.dateFormat : 'ddd, MMM Do';
+        let format = this.props.dateFormat || 'ddd, MMM Do';
+        if ('month' === this.props.display) {
+            format = 'dddd';
+        }
 
         return (
             <div className="x-labels">{this.days.map(day => <div key={day.format('YYYYMMDD')} className="day-label">

--- a/src/x-labels.js
+++ b/src/x-labels.js
@@ -23,15 +23,15 @@ export default class XLabels extends React.Component {
         return days;
     }
 
-    render() {
-        let format = this.props.dateFormat || 'ddd, MMM Do';
-        if ('month' === this.props.display) {
-            format = 'dddd';
-        }
+    get dateFormat() {
+        const defaultFormat = 'month' === this.props.display ? 'dddd' : 'ddd, MMM Do';
+        return this.props.dateFormat || defaultFormat;
+    }
 
+    render() {
         return (
             <div className="x-labels">{this.days.map(day => <div key={day.format('YYYYMMDD')} className="day-label">
-                {day.format(format)}
+                {day.format(this.dateFormat)}
             </div>)}
             </div>
         );

--- a/src/y-labels.js
+++ b/src/y-labels.js
@@ -22,7 +22,7 @@ export default class YLabels extends React.Component {
     }
 
     renderLabels() {
-        const day = moment();
+        const day = moment().startOf('hour');
         return this.hours.map(hour => <div key={hour} className="hour">{day.hour(hour).format(this.props.timeFormat)}</div>);
     }
 

--- a/test/__snapshots__/dayz.spec.js.snap
+++ b/test/__snapshots__/dayz.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Dayz limits days to min/max displayed 1`] = `
 "<Dayz displayHours={{...}} display=\\"week\\" date={{...}} events={{...}}>
   <div className=\\"dayz week\\">
-    <XLabels date={{...}} display=\\"week\\">
+    <XLabels date={{...}} display=\\"week\\" dateFormat={[undefined]}>
       <div className=\\"x-labels\\">
         <div className=\\"day-label\\">
           Sun, Nov 11th


### PR DESCRIPTION
Good component. But I found one bug.

If pass the `timeFormat` prop with value `HH:mm` then the calendar render with minutes from now:

![dayz](https://user-images.githubusercontent.com/48512663/58662254-0b1fa880-832a-11e9-8e91-2b32536e317b.png)

Also, I've added new props `dateFormat` for formatting the x label. What do you think about these changes?