### PR TITLE
Fix/single day event displayed as all day event when summer time changes to winter time

### DIFF
--- a/src/api/event.js
+++ b/src/api/event.js
@@ -76,7 +76,8 @@ export default class Event {
     }
 
     isSingleDay() {
-        return 24 > this.attributes.range.end.diff(this.attributes.range.start, 'hours');
+        const maxDiff = this.attributes.range.start.isDST() ? 25 : 24;
+        return maxDiff > this.attributes.range.end.diff(this.attributes.range.start, 'hours');
     }
 
     daysMinuteRange() {

--- a/test/event.spec.js
+++ b/test/event.spec.js
@@ -62,4 +62,14 @@ describe('Dayz', () => {
         expect(classList).toContain('span-1');
         expect(classList).toContain('is-continued');
     });
+
+    it('renders a single-day event when summer time changes to winter time', () => {
+        const dstDate = moment('2019-10-27');
+        const eventModel = new Event({
+            content: 'test',
+            range: moment.range(moment(dstDate).startOf('day'), moment(dstDate).endOf('day')),
+        });
+
+        expect(eventModel.isSingleDay()).toBe(true);
+    });
 });


### PR DESCRIPTION
## Description
When summer time changed to winter time an event from `00:00:00` until `23:59:59` is displayed as all day event because the difference returned from `momentjs` is `24` not `23`. This PR attempts to fix the display of the event.

**Types of changes**
What types of changes does your code introduce?
- Bugfix (non-breaking change which fixes an issue)

**Related links**
https://momentjs.com/docs/#/query/is-daylight-saving-time/

## Changelog
#### Added
- test case for DST date

#### Fixed
- `isSingleDay` function