### PR TITLE
Feature/add possibility to start week on sunday or monday

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ The Dayz component accepts these properties:
  * **onEventClick**, **onEventDoubleClick** (optional): A function that will be called whenever an event is clicked, it's passed two variables, the event and the layout information for the event.  The layout has an `event` subkey that includes the event itself.
  * **displayHours** (optional): defaults to 7am to 7pm or the earliest/latest event's hour.
  * **timeFormat** (optional): defaults to `ha` configures y labels time format
+ * **locale** (optional): defaults to `en`. A string to determine the localization.
+ * **weekStartsOn** (optional): defaults to `undefined`. Determines whether the week should start on Monday or Sunday. By default it uses what the localization offers (see `locale` prop). It can accept either `0` to start the week on Sunday or `1` to start the week on Monday.
 
 Dayz applies these css classes:
  * The reference **date** prop will have a css class "current"

--- a/src/api/layout.js
+++ b/src/api/layout.js
@@ -54,17 +54,44 @@ export default class Layout {
         if (this.range) {
             return;
         }
+
+        const start = moment(this.date);
+        const end = moment(this.date);
+
+        if ('week' === this.display) {
+            if (this.weekStartsOn !== undefined) {
+                start.startOf('isoWeek');
+                end.endOf('isoWeek');
+                if (0 === this.weekStartsOn && 1 === start.isoWeekday()) {
+                    start.subtract(1, 'day');
+                    end.subtract(1, 'day');
+                }
+            } else {
+                start.startOf(this.display);
+                end.endOf(this.display);
+            }
+        } else {
+            start.startOf(this.display);
+            end.endOf(this.display);
+        }
+
         this.range = moment.range(
-            moment(this.date).startOf(this.display),
-            moment(this.date).endOf(this.display),
+            start,
+            end,
         );
 
         if (this.isDisplayingAsMonth) {
+            let startWeekday = this.range.start.weekday();
+            let maxWeekday = 6;
+            if (this.weekStartsOn && 1 === this.weekStartsOn) {
+                startWeekday -= 1;
+                maxWeekday += 1;
+            }
             this.range.start.subtract(
-                this.range.start.weekday(), 'days',
+                startWeekday, 'days',
             );
             this.range.end.add(
-                6 - this.range.end.weekday(), 'days',
+                maxWeekday - this.range.end.isoWeekday(), 'days',
             );
         }
     }

--- a/src/api/layout.js
+++ b/src/api/layout.js
@@ -55,8 +55,8 @@ export default class Layout {
             return;
         }
 
-        const start = moment(this.date);
-        const end = moment(this.date);
+        const start = moment(this.date).locale(this.locale);
+        const end = moment(this.date).locale(this.locale);
 
         if ('week' === this.display) {
             if (this.weekStartsOn !== undefined) {
@@ -81,11 +81,16 @@ export default class Layout {
         );
 
         if (this.isDisplayingAsMonth) {
-            let startWeekday = this.range.start.weekday();
+            let startWeekday;
             let maxWeekday = 6;
-            if (this.weekStartsOn && 1 === this.weekStartsOn) {
-                startWeekday -= 1;
-                maxWeekday += 1;
+            if (this.weekStartsOn !== undefined) {
+                startWeekday = this.range.start.isoWeekday();
+                if (1 === this.weekStartsOn) {
+                    startWeekday -= 1;
+                    maxWeekday += 1;
+                }
+            } else {
+                startWeekday = this.range.start.weekday();
             }
             this.range.start.subtract(
                 startWeekday, 'days',

--- a/src/dayz.js
+++ b/src/dayz.js
@@ -25,6 +25,7 @@ export default class Dayz extends React.Component {
         highlightDays:     PropTypes.oneOfType(
             [PropTypes.array, PropTypes.func],
         ),
+        weekStartsOn:      PropTypes.number,
     }
 
     static defaultProps = {
@@ -95,6 +96,7 @@ export default class Dayz extends React.Component {
                     display={this.props.display}
                     dateFormat={this.props.dateFormat}
                     locale={this.props.locale}
+                    weekStartsOn={this.props.weekStartsOn}
                 />
                 <div className="body">
                     <YLabels

--- a/src/dayz.js
+++ b/src/dayz.js
@@ -25,7 +25,7 @@ export default class Dayz extends React.Component {
         highlightDays:     PropTypes.oneOfType(
             [PropTypes.array, PropTypes.func],
         ),
-        weekStartsOn:      PropTypes.number,
+        weekStartsOn:      PropTypes.oneOf([0, 1]),
     }
 
     static defaultProps = {

--- a/src/x-labels.js
+++ b/src/x-labels.js
@@ -5,18 +5,30 @@ import PropTypes from 'prop-types';
 export default class XLabels extends React.Component {
 
     static propTypes = {
-        display:    PropTypes.oneOf(['month', 'week', 'day']),
-        date:       PropTypes.object.isRequired,
-        dateFormat: PropTypes.string,
-        locale:     PropTypes.string.isRequired,
+        display:      PropTypes.oneOf(['month', 'week', 'day']),
+        date:         PropTypes.object.isRequired,
+        dateFormat:   PropTypes.string,
+        locale:       PropTypes.string.isRequired,
+        weekStartsOn: PropTypes.number,
     }
 
     get days() {
         const days = [];
+
         if ('day' === this.props.display) {
             days.push(moment(this.props.date));
         } else {
-            const day = moment(this.props.date).locale(this.props.locale).startOf('week');
+            let startOfType = 'week';
+            const day = moment(this.props.date).locale(this.props.locale);
+            if (this.props.weekStartsOn) {
+                startOfType = 'isoWeek';
+                day.startOf(startOfType);
+                if (0 === this.props.weekStartsOn && 1 === day.isoWeekday()) {
+                    day.subtract(1, 'day');
+                }
+            } else {
+                day.startOf(startOfType);
+            }
             for (let i = 0; i < 7; i += 1) {
                 days.push(day.clone().add(i, 'day'));
             }

--- a/src/x-labels.js
+++ b/src/x-labels.js
@@ -9,7 +9,7 @@ export default class XLabels extends React.Component {
         date:         PropTypes.object.isRequired,
         dateFormat:   PropTypes.string,
         locale:       PropTypes.string.isRequired,
-        weekStartsOn: PropTypes.number,
+        weekStartsOn: PropTypes.oneOf([0, 1]),
     }
 
     get days() {

--- a/src/x-labels.js
+++ b/src/x-labels.js
@@ -43,9 +43,10 @@ export default class XLabels extends React.Component {
 
     render() {
         return (
-            <div className="x-labels">{this.days.map(day => <div key={day.format('YYYYMMDD')} className="day-label">
-                {day.locale(this.props.locale).format(this.dateFormat)}
-            </div>)}
+            <div className="x-labels">
+                {this.days.map(day => <div key={day.format('YYYYMMDD')} className="day-label">
+                    {day.locale(this.props.locale).format(this.dateFormat)}
+                </div>)}
             </div>
         );
     }

--- a/src/x-labels.js
+++ b/src/x-labels.js
@@ -20,7 +20,7 @@ export default class XLabels extends React.Component {
         } else {
             let startOfType = 'week';
             const day = moment(this.props.date).locale(this.props.locale);
-            if (this.props.weekStartsOn) {
+            if (this.props.weekStartsOn !== undefined) {
                 startOfType = 'isoWeek';
                 day.startOf(startOfType);
                 if (0 === this.props.weekStartsOn && 1 === day.isoWeekday()) {

--- a/test/__snapshots__/dayz.spec.js.snap
+++ b/test/__snapshots__/dayz.spec.js.snap
@@ -225,29 +225,12 @@ exports[`Dayz localizes to specified locale 1`] = `
     >
       <div
         className="day before outside"
-        data-date="20150830"
-        onClick={[Function]}
-        onDoubleClick={[Function]}
-        style={
-          Object {
-            "order": 0,
-          }
-        }
-      >
-        <div
-          className="label"
-        >
-          30
-        </div>
-      </div>
-      <div
-        className="day before outside"
         data-date="20150831"
         onClick={[Function]}
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 1,
+            "order": 0,
           }
         }
       >
@@ -264,7 +247,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 2,
+            "order": 1,
           }
         }
       >
@@ -281,7 +264,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 3,
+            "order": 2,
           }
         }
       >
@@ -298,7 +281,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 4,
+            "order": 3,
           }
         }
       >
@@ -315,7 +298,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 5,
+            "order": 4,
           }
         }
       >
@@ -332,7 +315,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 6,
+            "order": 5,
           }
         }
       >
@@ -349,7 +332,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 7,
+            "order": 6,
           }
         }
       >
@@ -366,7 +349,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 8,
+            "order": 7,
           }
         }
       >
@@ -383,7 +366,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 9,
+            "order": 8,
           }
         }
       >
@@ -400,7 +383,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 10,
+            "order": 9,
           }
         }
       >
@@ -417,7 +400,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 11,
+            "order": 10,
           }
         }
       >
@@ -434,7 +417,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 12,
+            "order": 11,
           }
         }
       >
@@ -451,7 +434,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 13,
+            "order": 12,
           }
         }
       >
@@ -468,7 +451,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 14,
+            "order": 13,
           }
         }
       >
@@ -485,7 +468,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 15,
+            "order": 14,
           }
         }
       >
@@ -502,7 +485,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 16,
+            "order": 15,
           }
         }
       >
@@ -519,7 +502,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 17,
+            "order": 16,
           }
         }
       >
@@ -536,7 +519,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 18,
+            "order": 17,
           }
         }
       >
@@ -553,7 +536,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 19,
+            "order": 18,
           }
         }
       >
@@ -570,7 +553,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 20,
+            "order": 19,
           }
         }
       >
@@ -587,7 +570,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 21,
+            "order": 20,
           }
         }
       >
@@ -604,7 +587,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 22,
+            "order": 21,
           }
         }
       >
@@ -621,7 +604,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 23,
+            "order": 22,
           }
         }
       >
@@ -638,7 +621,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 24,
+            "order": 23,
           }
         }
       >
@@ -655,7 +638,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 25,
+            "order": 24,
           }
         }
       >
@@ -672,7 +655,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 26,
+            "order": 25,
           }
         }
       >
@@ -689,7 +672,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 27,
+            "order": 26,
           }
         }
       >
@@ -706,7 +689,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 28,
+            "order": 27,
           }
         }
       >
@@ -723,7 +706,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 29,
+            "order": 28,
           }
         }
       >
@@ -740,7 +723,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 30,
+            "order": 29,
           }
         }
       >
@@ -757,7 +740,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 31,
+            "order": 30,
           }
         }
       >
@@ -774,7 +757,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 32,
+            "order": 31,
           }
         }
       >
@@ -791,7 +774,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 33,
+            "order": 32,
           }
         }
       >
@@ -808,7 +791,7 @@ exports[`Dayz localizes to specified locale 1`] = `
         onDoubleClick={[Function]}
         style={
           Object {
-            "order": 34,
+            "order": 33,
           }
         }
       >

--- a/test/__snapshots__/dayz.spec.js.snap
+++ b/test/__snapshots__/dayz.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`Dayz limits days to min/max displayed 1`] = `
 "<Dayz displayHours={{...}} display=\\"week\\" date={{...}} events={{...}} locale=\\"en\\">
   <div className=\\"dayz week\\">
-    <XLabels date={{...}} display=\\"week\\" dateFormat={[undefined]} locale=\\"en\\">
+    <XLabels date={{...}} display=\\"week\\" dateFormat={[undefined]} locale=\\"en\\" weekStartsOn={[undefined]}>
       <div className=\\"x-labels\\">
         <div className=\\"day-label\\">
           Sun, Nov 11th

--- a/test/layout.spec.js
+++ b/test/layout.spec.js
@@ -1,6 +1,6 @@
 import React from 'react'; // eslint-disable-line no-unused-vars
 import moment from '../src/moment-range';
-import { testEventMonth, testEventRange, testEventDay } from './testing-layouts';
+import { testEventMonth, testEventRange, testEventDay, testWeekStartsOn } from './testing-layouts';
 
 describe('Layout calculations', () => {
     describe('day layout', () => {
@@ -158,6 +158,60 @@ describe('Layout calculations', () => {
             expect(layout.propsForDayContainer({
                 day: moment('2018-11-12'),
             })).toMatchObject({ className: 'day after tenth' });
+        });
+    });
+
+    describe('weekStartsOn', () => {
+        describe('month layout', () => {
+            describe('default', () => {
+                it('starts the week on Sunday for "en" locale', () => {
+                    const layout = testWeekStartsOn({ locale: 'en' });
+                    expect(layout.range.start.isoWeekday()).toBe(7);
+                });
+
+                it('starts the week on Monday for "de" locale', () => {
+                    const layout = testWeekStartsOn({ locale: 'de' });
+                    expect(layout.range.start.isoWeekday()).toBe(1);
+                });
+            });
+
+            describe('weekStartsOn set', () => {
+                it('starts the week on Sunday when 0', () => {
+                    const layout = testWeekStartsOn({ locale: 'de', weekStartsOn: 0 });
+                    expect(layout.range.start.isoWeekday()).toBe(7);
+                });
+
+                it('starts the week on Monday when 1', () => {
+                    const layout = testWeekStartsOn({ locale: 'en', weekStartsOn: 1 });
+                    expect(layout.range.start.isoWeekday()).toBe(1);
+                });
+            });
+        });
+
+        describe('week layout', () => {
+            describe('default', () => {
+                it('starts the week on Sunday for "en" locale', () => {
+                    const layout = testWeekStartsOn({ locale: 'en' });
+                    expect(layout.range.start.isoWeekday()).toBe(7);
+                });
+
+                it('starts the week on Monday for "de" locale', () => {
+                    const layout = testWeekStartsOn({ locale: 'de' });
+                    expect(layout.range.start.isoWeekday()).toBe(1);
+                });
+            });
+
+            describe('weekStartsOn set', () => {
+                it('starts the week on Sunday when 0', () => {
+                    const layout = testWeekStartsOn({ locale: 'de', weekStartsOn: 0 });
+                    expect(layout.range.start.isoWeekday()).toBe(7);
+                });
+
+                it('starts the week on Monday when 1', () => {
+                    const layout = testWeekStartsOn({ locale: 'en', weekStartsOn: 1 });
+                    expect(layout.range.start.isoWeekday()).toBe(1);
+                });
+            });
         });
     });
 });

--- a/test/testing-layouts.js
+++ b/test/testing-layouts.js
@@ -67,3 +67,13 @@ const testEventMonth = (options = {}) => {
     }, options));
     return layout;
 };
+
+export
+const testWeekStartsOn = (options = {}, display = 'month', events = new EventsCollection([])) => {
+    const layout = new Layout(Object.assign({
+        date: '2019-10-15',
+        display,
+        events,
+    }, options));
+    return layout;
+};


### PR DESCRIPTION
## Description
Until this point there was no option to set which day the week should start on. Because of the `locale` prop to `XLabels` component was updated however the `Layout` wasn't so the labels and the days with the events didn't match. This PR fixes this bug and also adds the opportunity leave the starting day to the `locale` prop or set it to Sunday or Monday no matter the localization.

**Types of changes**
What types of changes does your code introduce? Only leave matching option:
- New feature (non-breaking change which adds functionality)
- Bugfix (non-breaking change which fixes an issue)

**Related links**
https://momentjs.com/docs/#/get-set/day-of-year/
https://momentjs.com/docs/#/get-set/iso-weekday/

## Changelog
#### Added
- `weekStartsOn` prop to `Dayz`
- `weekStartsOn` prop to `XLabels`
- tests for `calculateRange`'s new cases

#### Changed
- README
- `calculateRange` function in `Layout`
- `days` function in `XLabels`
- updated snapshots