### PR TITLE
Fix for second event now showing when range is less than a day and event spans across 2 days

### DIFF
--- a/src/api/events-collection.js
+++ b/src/api/events-collection.js
@@ -21,7 +21,7 @@ export default class EventsCollection {
             if (options.displayAllDay) {
                 this.add(events[i], { silent: true });
             } else {
-                Array.from(events[i].range.by('day')).map(date => (
+                Array.from(events[i].range.snapTo('days').by('day')).map(date => (
                     this.add(events[i], { silent: true, eventDay: date.clone() })
                 ));
             }

--- a/test/events-collection.spec.js
+++ b/test/events-collection.spec.js
@@ -3,33 +3,61 @@ import Event from '../src/api/event';
 import moment from '../src/moment-range';
 
 describe('Events Collection', () => {
-    it('creates events from object', () => {
-        const collection = new EventsCollection([
-            { range: moment.range('2011-10-01', '2011-10-02') },
-        ]);
-        expect(collection.events.length).toEqual(1);
-        const event = collection.events[0];
-        expect(event).toEqual(expect.any(Event));
-        expect(event.range().isSame(moment.range('2011-10-01', '2011-10-02'))).toBe(true);
+    describe('display events as all day events', () => {
+        it('creates events from object', () => {
+            const collection = new EventsCollection([
+                { range: moment.range('2011-10-01', '2011-10-02') },
+            ]);
+            expect(collection.events.length).toEqual(1);
+            const event = collection.events[0];
+            expect(event).toEqual(expect.any(Event));
+            expect(event.range().isSame(moment.range('2011-10-01', '2011-10-02'))).toBe(true);
+        });
     });
 
-    it('creates events from object', () => {
-        const collection = new EventsCollection(
-            [{ range: moment.range('2011-10-01', '2011-10-02 12:00:01') }],
-            { displayAllDay: false },
-        );
-        expect(collection.events.length).toEqual(2);
+    describe('display events as multiple NOT all day events', () => {
+        describe('range is more than one day', () => {
+            it('creates events from object', () => {
+                const collection = new EventsCollection(
+                    [{ range: moment.range('2011-10-01', '2011-10-02 12:00:01') }],
+                    { displayAllDay: false },
+                );
+                expect(collection.events.length).toEqual(2);
 
-        const event = collection.events[0];
-        expect(event).toEqual(expect.any(Event));
-        expect(event.range().isSame(
-            moment.range('2011-10-01 00:00:00', '2011-10-01 23:59:59.999'),
-        )).toBe(true);
+                const event = collection.events[0];
+                expect(event).toEqual(expect.any(Event));
+                expect(event.range().isSame(
+                    moment.range('2011-10-01 00:00:00', '2011-10-01 23:59:59.999'),
+                )).toBe(true);
 
-        const event_b = collection.events[1];
-        expect(event_b).toEqual(expect.any(Event));
-        expect(event_b.range().isSame(
-            moment.range('2011-10-02 00:00:00', '2011-10-02 12:00:01'),
-        )).toBe(true);
+                const event_b = collection.events[1];
+                expect(event_b).toEqual(expect.any(Event));
+                expect(event_b.range().isSame(
+                    moment.range('2011-10-02 00:00:00', '2011-10-02 12:00:01'),
+                )).toBe(true);
+            });
+        });
+
+        describe('range is less than one day', () => {
+            it('creates events from object', () => {
+                const collection = new EventsCollection(
+                    [{ range: moment.range('2011-10-01 20:00:00', '2011-10-02 08:00:00') }],
+                    { displayAllDay: false },
+                );
+                expect(collection.events.length).toEqual(2);
+
+                const event = collection.events[0];
+                expect(event).toEqual(expect.any(Event));
+                expect(event.range().isSame(
+                    moment.range('2011-10-01 20:00:00', '2011-10-01 23:59:59.999'),
+                )).toBe(true);
+
+                const event_b = collection.events[1];
+                expect(event_b).toEqual(expect.any(Event));
+                expect(event_b.range().isSame(
+                    moment.range('2011-10-02 00:00:00', '2011-10-02 08:00:00'),
+                )).toBe(true);
+            });
+        });
     });
 });


### PR DESCRIPTION
## Description
If for `EventsCollection` the `displayAllDay` flag was set to `false` and the range was less than a day and the event spanned across 2 days (i.e. `2019-10-25 23:00:00` - `2019-10-26 09:00:00`) then the event for the second day didn't show. This PR fixes this issue.

**Types of changes**
- Bugfix (non-breaking change which fixes an issue)

**Related links**
https://github.com/rotaready/moment-range#snapto
https://github.com/rotaready/moment-range#by - see the part when `.snapTo()` method is used

## Changelog
#### Added
- test for case when range is less than one day but event spans across 2 days

#### Fixed
- `EventsCollection`'s `constructor` when it calculates the days for events